### PR TITLE
fix the shebangs

### DIFF
--- a/bin/cligh
+++ b/bin/cligh
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 """Simple command-line interface to github."""
 # See the file LICENSE for copyright and license info.
 import argparse

--- a/cligh/collaborators.py
+++ b/cligh/collaborators.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 # Commands for managing collaborators.
 
 from . import utils

--- a/cligh/issues.py
+++ b/cligh/issues.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 """Commands for managing and querying issues."""
 
 from github import GithubException

--- a/cligh/repos.py
+++ b/cligh/repos.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 # Repository-related commands.
 
 from cligh.utils import get_working_repo, read_user_input, die

--- a/cligh/utils.py
+++ b/cligh/utils.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 import os
 import os.path
 import re

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from distutils.core import setup
 
 setup(


### PR DESCRIPTION
In bin/cligh and setup.py, make sure that py3 is being run. Remove the
shebangs from the modules of the cligh package since these aren't meant
to be run standalone.