### PR TITLE
Escape dots in a regexp.

### DIFF
--- a/cligh/utils.py
+++ b/cligh/utils.py
@@ -49,9 +49,9 @@ we try to detect the repository's name by looking at remote.origin.url."""
 	if not name:
 		name = read_git_config('remote.origin.url')
 		match = re.match(r'''(?x)
-			(?:git@github.com:     # ssh
-			|git://github.com/ # git protocol
-			|https://github.com/)  # https
+			(?:git@github\.com:    # ssh
+			|git://github\.com/    # git protocol
+			|https://github\.com/) # https
 			(.+)                   # user/repo
 			(?:\.git               # optional extension
 			|(?<!\.git))           # anything but extension


### PR DESCRIPTION
Regexp in `get_repository_name()` contained strings `github.com` with unescaped dots.