### PR TITLE
Add missing import of GithubException.

### DIFF
--- a/cligh/utils.py
+++ b/cligh/utils.py
@@ -6,6 +6,8 @@ import subprocess
 import sys
 import tempfile
 
+from github import GithubException
+
 # Helper functions.
 def print_error(message):
 	"""Display an error message."""


### PR DESCRIPTION
Fixes:
```
NameError: name 'GithubException' is not defined
```
when user cannot be found.